### PR TITLE
fix: resolve geometry crash, React key warnings, and switch connections

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -5,14 +5,16 @@ import { LedCircuit } from "./lib/LedCircuit"
 import { FlashCircuit } from "./lib/FlashCircuit"
 import { CrystalCircuit } from "./lib/CrystalCircuit"
 import { RP2040Circuit } from "./lib/RP2040Circuit"
+import { KeyCircuit } from "./lib/KeyCircuit"
 
 export default () => (
-  <board routingDisabled schMaxTraceDistance={5}>
+  <board pcbPack routingDisabled schMaxTraceDistance={5}>
     <VoltageRegulator />
     <PinOutCircuit />
     <LedCircuit />
     <FlashCircuit />
     <CrystalCircuit />
+    <KeyCircuit />
     <RP2040Circuit />
   </board>
 )

--- a/lib/KeyCircuit.tsx
+++ b/lib/KeyCircuit.tsx
@@ -5,6 +5,7 @@ export const KeyCircuit = () => (
     <resistor
       name="R2"
       resistance="1k"
+      footprint="0402"
       connections={{
         pin1: "net.QSPI_SS_N",
       }}

--- a/lib/KeyCircuit.tsx
+++ b/lib/KeyCircuit.tsx
@@ -14,6 +14,8 @@ export const KeyCircuit = () => (
       connections={{
         pin1: "R2.2",
         pin2: "net.GND",
+        pin3: "R2.2",
+        pin4: "net.GND",
       }}
     />
     <TS_1187A_B_A_B
@@ -21,6 +23,8 @@ export const KeyCircuit = () => (
       connections={{
         pin1: "net.RUN",
         pin2: "net.GND",
+        pin3: "net.RUN",
+        pin4: "net.GND",
       }}
     />
   </group>

--- a/lib/PinOutCircuit.tsx
+++ b/lib/PinOutCircuit.tsx
@@ -1,7 +1,7 @@
 export const PinOutCircuit = () => (
   <chip
     name="P1"
-    footprint="stampboard_left9_right9_bottom5_top0_p2.54mm_innerhole_h23.8mm_showpinlabels"
+    footprint="stampboard_left9_right9_bottom5_top0_p2.54mm_h23.8mm_showpinlabels"
     schWidth={1}
     schPinArrangement={{
       leftSide: {

--- a/lib/RP2040Circuit.tsx
+++ b/lib/RP2040Circuit.tsx
@@ -25,6 +25,7 @@ export const RP2040Circuit = () => (
     {/* Decoupling Capacitors for IOVDD */}
     {["C12", "C14", "C8", "C13", "C15", "C19"].map((cName) => (
       <capacitor
+        key={cName}
         name={cName}
         capacitance="100nF"
         schOrientation="vertical"


### PR DESCRIPTION
This PR resolves three critical issues discovered during the hardware-to-code synthesis:

Geometry Engine Crash: Removed unsupported _innerhole parameters from the PinOutCircuit stampboard footprint and implemented pcpPack in the main board configuration to ensure valid geometry generation.

React Prop Warnings: Added unique key={cName} props to the IOVDD capacitor mapping in RP2040Circuit.tsx to resolve console errors during the build process.

Trace Routing Warnings: Tied redundant pins (3 and 4) to their respective nets on the TS_1187A_B_A_B switches in KeyCircuit.tsx. This completes the electrical path for all physical pads on the footprint and clears autorouter "missing trace" warnings.